### PR TITLE
Expose setIsImporting in useEntityManagement hook

### DIFF
--- a/src/hooks/useCategoryManagement.ts
+++ b/src/hooks/useCategoryManagement.ts
@@ -51,7 +51,7 @@ export const useCategoryManagement = () => {
       if (managementProps.fileInputRef.current) managementProps.fileInputRef.current.value = "";
     },
     onError: (error: any) => showError(`Import failed: ${error.message}`),
-    onSettled: () => (managementProps as any).setIsImporting(false),
+    onSettled: () => managementProps.setIsImporting(false),
   });
 
   const addSubCategoryMutation = useMutation({
@@ -116,7 +116,7 @@ export const useCategoryManagement = () => {
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file || !activeLedger) return;
-    (managementProps as any).setIsImporting(true);
+    managementProps.setIsImporting(true);
 
     Papa.parse(file, {
       header: true,
@@ -125,20 +125,20 @@ export const useCategoryManagement = () => {
         const hasHeader = results.meta.fields?.includes("Category Name");
         if (!hasHeader) {
           showError(`CSV is missing required header: "Category Name"`);
-          (managementProps as any).setIsImporting(false);
+          managementProps.setIsImporting(false);
           return;
         }
         const categoryNames = results.data.map((row: any) => row["Category Name"]).filter(Boolean);
         if (categoryNames.length === 0) {
           showError("No valid category names found in the CSV file.");
-          (managementProps as any).setIsImporting(false);
+          managementProps.setIsImporting(false);
           return;
         }
         batchUpsertCategoriesMutation.mutate(categoryNames);
       },
       error: (error: any) => {
         showError(`CSV parsing error: ${error.message}`);
-        (managementProps as any).setIsImporting(false);
+        managementProps.setIsImporting(false);
       },
     });
   };

--- a/src/hooks/useEntityManagement.ts
+++ b/src/hooks/useEntityManagement.ts
@@ -170,7 +170,7 @@ export const useEntityManagement = <T extends { id: string; name: string }>({
     selectedEntity,
     isConfirmOpen, setIsConfirmOpen,
     selectedRows,
-    isImporting, fileInputRef,
+    isImporting, setIsImporting, fileInputRef,
     deleteMutation,
     batchUpsertMutation,
     isLoadingMutation: deleteMutation.isPending || batchUpsertMutation.isPending,

--- a/src/hooks/usePayeeManagement.ts
+++ b/src/hooks/usePayeeManagement.ts
@@ -29,7 +29,7 @@ export const usePayeeManagement = (isAccount: boolean) => {
     const file = event.target.files?.[0];
     if (!file) return;
     managementProps.batchUpsertMutation.reset(); // Reset mutation state
-    const setIsImporting = (managementProps as any).setIsImporting; // A bit of a hack, ideally the hook would expose this
+    const { setIsImporting } = managementProps;
     setIsImporting(true);
 
     Papa.parse(file, {


### PR DESCRIPTION
Refactored `useEntityManagement` to explicitly expose `setIsImporting`, removing the need for type casting and internal state access in consuming hooks (`usePayeeManagement` and `useCategoryManagement`). This improves type safety and code maintainability.

---
*PR created automatically by Jules for task [18111801497112403860](https://jules.google.com/task/18111801497112403860) started by @nrajesh*