### PR TITLE
Remove vestigial code in search parser

### DIFF
--- a/src/tests/nlp-search.test.ts
+++ b/src/tests/nlp-search.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { parseSearchQuery } from '../utils/nlp-search';
+
+describe('parseSearchQuery', () => {
+    beforeEach(() => {
+        // Mock the date to a fixed point in time: 2023-10-10 12:00:00
+        vi.useFakeTimers();
+        const date = new Date(2023, 9, 10, 12, 0, 0); // Month is 0-indexed, so 9 is October
+        vi.setSystemTime(date);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should correctly parse "today" query', () => {
+        const query = 'today';
+        const result = parseSearchQuery(query);
+
+        expect(result.dateRange).toBeDefined();
+
+        const expectedStart = new Date(2023, 9, 10, 0, 0, 0, 0);
+        const expectedEnd = new Date(2023, 9, 10, 23, 59, 59, 999);
+
+        expect(result.dateRange?.from).toEqual(expectedStart);
+        expect(result.dateRange?.to).toEqual(expectedEnd);
+    });
+});

--- a/src/utils/nlp-search.ts
+++ b/src/utils/nlp-search.ts
@@ -45,7 +45,6 @@ export const parseSearchQuery = (query: string): SearchFilters => {
     } else if (lowerQuery.includes('today')) {
         const startToday = new Date(today);
         startToday.setHours(0, 0, 0, 0);
-        filters.dateRange = { from: startToday, to: endOfWeek(today) }; // Use end of day? Fix below.
         const endToday = new Date(today);
         endToday.setHours(23, 59, 59, 999);
         filters.dateRange = { from: startToday, to: endToday };


### PR DESCRIPTION
Removed a line of dead code in `src/utils/nlp-search.ts` where `filters.dateRange` was assigned but immediately overwritten. Added a regression test to ensure the logic remains correct.

---
*PR created automatically by Jules for task [14712553513069671334](https://jules.google.com/task/14712553513069671334) started by @nrajesh*