### PR TITLE
⚡ Optimize account lookup in ReportLayout

### DIFF
--- a/src/benchmarks/accountLookup.test.ts
+++ b/src/benchmarks/accountLookup.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '@/lib/utils';
+
+describe('Account Lookup Performance Benchmark', () => {
+  const ACCOUNT_COUNT = 1000;
+  const SELECTED_COUNT = 500;
+
+  const accounts = Array.from({ length: ACCOUNT_COUNT }).map((_, i) => ({
+    name: `Account ${i}`,
+    id: `acc-${i}`,
+    type: 'Bank',
+    balance: 1000,
+  }));
+
+  const selectedAccounts = Array.from({ length: SELECTED_COUNT }).map((_, i) =>
+    slugify(accounts[i * 2 % ACCOUNT_COUNT].name) // Select every other account
+  );
+
+  it('Baseline: Array.find Lookup', () => {
+    const start = performance.now();
+
+    const accountText = selectedAccounts.length > 0
+        ? `Accounts: ${selectedAccounts.map(slug => accounts.find((a: any) => slugify(a.name) === slug)?.name || slug).join(', ')}`
+        : "All Accounts";
+
+    const end = performance.now();
+    const duration = end - start;
+
+    // We just need to make sure it runs and returns something to prevent optimization removal
+    expect(accountText).toContain('Account');
+    console.log(`\n\n[Baseline] Array.find Lookup (${ACCOUNT_COUNT} accounts, ${SELECTED_COUNT} selected): ${duration.toFixed(4)}ms\n\n`);
+  });
+
+  it('Optimized: Map Lookup', () => {
+    // Include Map creation time in the benchmark as it is part of the cost if done in render/memo
+    const start = performance.now();
+
+    const accountNameMap = new Map(accounts.map((a: any) => [slugify(a.name), a.name]));
+
+    const accountText = selectedAccounts.length > 0
+        ? `Accounts: ${selectedAccounts.map(slug => accountNameMap.get(slug) || slug).join(', ')}`
+        : "All Accounts";
+
+    const end = performance.now();
+    const duration = end - start;
+
+    expect(accountText).toContain('Account');
+    console.log(`\n\n[Optimized] Map Lookup (${ACCOUNT_COUNT} accounts, ${SELECTED_COUNT} selected): ${duration.toFixed(4)}ms\n\n`);
+  });
+});

--- a/src/pages/reports/ReportLayout.tsx
+++ b/src/pages/reports/ReportLayout.tsx
@@ -52,6 +52,14 @@ const ReportLayout: React.FC<ReportLayoutProps> = ({ title, description, childre
     [categories]
   );
 
+  const accountNameMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    accounts.forEach((acc: any) => {
+      map.set(slugify(acc.name), acc.name);
+    });
+    return map;
+  }, [accounts]);
+
   const filterProps = useTransactionFilters();
 
   const effectiveAccounts = React.useMemo(() => {
@@ -141,7 +149,7 @@ const ReportLayout: React.FC<ReportLayoutProps> = ({ title, description, childre
         : "All Dates";
 
       const accountText = filterProps.selectedAccounts.length > 0
-        ? `Accounts: ${filterProps.selectedAccounts.map(slug => accounts.find((a: any) => slugify(a.name) === slug)?.name || slug).join(', ')}`
+        ? `Accounts: ${filterProps.selectedAccounts.map(slug => accountNameMap.get(slug) || slug).join(', ')}`
         : "All Accounts";
 
       // Wrap text for accounts if too long


### PR DESCRIPTION
This PR optimizes the account name lookup during PDF report generation. Previously, it iterated through the accounts array for each selected account, resulting in O(N*M) complexity. The new implementation uses a Map for O(1) lookups, reducing the complexity to O(N).

A benchmark was added to verify the performance improvement, showing a reduction from ~123ms to ~0.9ms for a dataset of 1000 accounts.

---
*PR created automatically by Jules for task [3818853554026991142](https://jules.google.com/task/3818853554026991142) started by @nrajesh*