### PR TITLE
Fix abstraction leak in sub-category renaming

### DIFF
--- a/src/hooks/useCategoryManagement.ts
+++ b/src/hooks/useCategoryManagement.ts
@@ -67,17 +67,9 @@ export const useCategoryManagement = () => {
   });
 
   const renameSubCategoryMutation = useMutation({
-    mutationFn: async ({ categoryId, categoryName, oldSubCategoryName, newSubCategoryName }: { categoryId: string; categoryName: string; oldSubCategoryName: string; newSubCategoryName: string }) => {
+    mutationFn: async ({ categoryId, oldSubCategoryName, newSubCategoryName }: { categoryId: string; categoryName: string; oldSubCategoryName: string; newSubCategoryName: string }) => {
       if (!activeLedger?.id) throw new Error("No active ledger.");
-
-      // Pragmatic fix: use db directly for complex updates not in provider interface yet
-      await db.sub_categories
-        .where({ category_id: categoryId, name: oldSubCategoryName })
-        .modify({ name: newSubCategoryName.trim() });
-
-      await db.transactions
-        .where({ category: categoryName, sub_category: oldSubCategoryName })
-        .modify({ sub_category: newSubCategoryName.trim() });
+      await dataProvider.renameSubCategory(categoryId, oldSubCategoryName, newSubCategoryName, activeLedger.id);
     },
     onSuccess: async () => {
       showSuccess("Sub-category renamed successfully!");

--- a/src/types/dataProvider.ts
+++ b/src/types/dataProvider.ts
@@ -146,6 +146,7 @@ export interface DataProvider {
   getSubCategories(userId: string): Promise<SubCategory[]>;
   mergeCategories(targetName: string, sourceNames: string[], userId: string): Promise<void>;
   deleteCategory(id: string): Promise<void>;
+  renameSubCategory(categoryId: string, oldName: string, newName: string, userId: string): Promise<void>;
 
   // Budgets
   getBudgetsWithSpending(userId: string): Promise<Budget[]>;


### PR DESCRIPTION
Fixed an abstraction leak in `src/hooks/useCategoryManagement.ts` where `renameSubCategoryMutation` was accessing the Dexie database directly.
Moved the logic to `LocalDataProvider`, ensuring proper abstraction and adding transactional safety.
Also fixed a potential issue where renaming a sub-category could affect transactions in other ledgers by adding proper `user_id` scoping.

---
*PR created automatically by Jules for task [7740182985230901952](https://jules.google.com/task/7740182985230901952) started by @nrajesh*