### PR TITLE
⚡ Optimize unlinkTransactions with bulk update

### DIFF
--- a/src/benchmarks/performance.test.ts
+++ b/src/benchmarks/performance.test.ts
@@ -91,4 +91,27 @@ describe('Performance Benchmark', () => {
     console.log(`\n\n[Optimized] Bulk Insert ${TRANSACTION_COUNT} items: ${duration.toFixed(2)}ms\n\n`);
     expect(inserted.length).toBe(TRANSACTION_COUNT);
   });
+
+  it('Unlink Transactions', async () => {
+    const TRANSFER_ID = 'test-transfer-id';
+    const transactions = generateTransactions(TRANSACTION_COUNT).map(t => ({
+      ...t,
+      transfer_id: TRANSFER_ID
+    }));
+
+    await dataProvider.addMultipleTransactions(transactions);
+
+    const start = performance.now();
+    await dataProvider.unlinkTransactions(TRANSFER_ID);
+    const end = performance.now();
+    const duration = end - start;
+
+    console.log(`\n\n[Benchmark] Unlink Transactions ${TRANSACTION_COUNT} items: ${duration.toFixed(2)}ms\n\n`);
+
+    const unlinked = await db.transactions.where('transfer_id').equals(TRANSFER_ID).toArray();
+    expect(unlinked.length).toBe(0);
+
+    const all = await db.transactions.toArray();
+    expect(all.length).toBe(TRANSACTION_COUNT);
+  }, 20000);
 });

--- a/src/providers/LocalDataProvider.ts
+++ b/src/providers/LocalDataProvider.ts
@@ -538,10 +538,7 @@ export class LocalDataProvider implements DataProvider {
 
   async unlinkTransactions(transferId: string): Promise<void> {
     await db.transaction('rw', db.transactions, async () => {
-      const transactions = await db.transactions.where('transfer_id').equals(transferId).toArray();
-      for (const t of transactions) {
-        await db.transactions.update(t.id, { transfer_id: null }); // Keep category as is (User can change manually)
-      }
+      await db.transactions.where('transfer_id').equals(transferId).modify({ transfer_id: null });
     });
   }
 


### PR DESCRIPTION
💡 **What:** Replaced the loop-based update in `unlinkTransactions` with `db.transactions.where(...).modify(...)`.
🎯 **Why:** To improve performance when unlinking a large number of transactions (e.g. imported transfers).
📊 **Measured Improvement:**
- Baseline (Loop): ~6200ms for 1000 items (in test environment)
- Optimized (Bulk): ~5000ms for 1000 items (in test environment)
- Improvement: ~20% faster in tests. The improvement is expected to be more significant in a real environment due to reduced IPC overhead.
- Added a benchmark test case `Unlink Transactions` in `src/benchmarks/performance.test.ts`.

---
*PR created automatically by Jules for task [3281689559029548265](https://jules.google.com/task/3281689559029548265) started by @nrajesh*