### PR TITLE
🎨 Palette: Improve Budget Card Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 ## 2025-02-11 - Semantic Buttons in Tables
 **Learning:** Using `div` with `onClick` for table cell actions (like filtering) makes them inaccessible to keyboard users and screen readers.
 **Action:** Replace interactive `div`s with `<button>` elements. Use utility classes like `bg-transparent border-0 p-0 text-left` to reset button styles while maintaining the original look, and add `aria-label` for context. For components like `Badge`, wrap the content in a button or use the component's variant styles on a button element if possible.
+
+## 2026-02-11 - Global Tooltip Availability
+**Learning:** The `SidebarProvider` in `Layout.tsx` wraps the application content with a `TooltipProvider`. This means `Tooltip` components can be used anywhere within the main layout without needing a local `TooltipProvider`.
+**Action:** When adding tooltips to components inside the main layout, directly use `Tooltip`, `TooltipTrigger`, and `TooltipContent` without wrapping them in a new provider.

--- a/src/components/budgets/BudgetCard.tsx
+++ b/src/components/budgets/BudgetCard.tsx
@@ -10,6 +10,11 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import { Edit, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { formatCurrency } from "@/lib/utils";
 import { format, startOfMonth, endOfMonth, endOfDay, parseISO } from "date-fns";
 import { useNavigate } from "react-router-dom";
@@ -148,16 +153,37 @@ export function BudgetCard({ budget, onEdit, onDelete }: BudgetCardProps) {
         </div>
       </CardContent>
       <CardFooter className="flex justify-end space-x-2">
-        <Button variant="outline" size="icon" onClick={() => onEdit(budget)}>
-          <Edit className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="destructive"
-          size="icon"
-          onClick={() => onDelete(budget.id)}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => onEdit(budget)}
+              aria-label="Edit budget"
+            >
+              <Edit className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Edit Budget</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="destructive"
+              size="icon"
+              onClick={() => onDelete(budget.id)}
+              aria-label="Delete budget"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Delete Budget</p>
+          </TooltipContent>
+        </Tooltip>
       </CardFooter>
     </Card>
   );


### PR DESCRIPTION
*   💡 What: Added `aria-label` and tooltips to the Edit and Delete buttons in `BudgetCard`.
*   🎯 Why: To make the interface accessible to screen reader users and provide clarity on hover for sighted users.
*   ♿ Accessibility: Added `aria-label="Edit budget"` and `aria-label="Delete budget"` for screen readers. Added visual tooltips.

---
*PR created automatically by Jules for task [4829041716610557255](https://jules.google.com/task/4829041716610557255) started by @nrajesh*