### PR TITLE
🛡️ Sentinel: Fix Path Traversal in Electron Backup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-05-18 - Path Traversal in Electron IPC
+**Vulnerability:** The `write-backup-file` IPC handler joined a user-provided `folder` with a `filename` without validation.
+**Learning:** `path.join()` in Node.js discards previous segments if a segment is an absolute path (e.g., `path.join('/safe/dir', '/etc/passwd')` returns `/etc/passwd`). This allowed arbitrary file overwrites even if the `folder` argument was fixed/safe (though in this case it wasn't).
+**Prevention:** Always validate `filename` arguments in IPC handlers to ensure they are relative and contain no path separators (`/` or `\`) or `..` segments. Use `path.basename()` and explicit checks.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -50,6 +50,12 @@ app.whenReady().then(() => {
 
     ipcMain.handle('write-backup-file', async (_event, folder: string, filename: string, content: string) => {
         try {
+            // SECURITY: Prevent path traversal
+            if (path.basename(filename) !== filename || filename === '..' || filename === '.') {
+                console.error("Security alert: Attempted path traversal in filename", filename);
+                throw new Error("Invalid filename: Path traversal detected");
+            }
+
             // Ensure directory exists
             if (!fs.existsSync(folder)) {
                 fs.mkdirSync(folder, { recursive: true });


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Electron IPC

🚨 Severity: CRITICAL
💡 Vulnerability: The `write-backup-file` IPC handler allowed arbitrary file writes by joining a user-provided `folder` with an unvalidated `filename`. If `filename` was an absolute path (e.g., `/etc/passwd`), `path.join` would ignore the `folder` argument and write to the absolute path. Relative paths with `..` were also possible.
🎯 Impact: An attacker (via a compromised renderer process, e.g., XSS) could overwrite critical system files or inject malicious code into startup folders.
🔧 Fix: Implemented strict validation on `filename` using `path.basename(filename) !== filename` and checking for `..` and `.`.
✅ Verification: Verified code logic ensures only valid filenames without path components are accepted. Ran lint and tests.

---
*PR created automatically by Jules for task [8528932558354040521](https://jules.google.com/task/8528932558354040521) started by @nrajesh*