### PR TITLE
🛡️ Sentinel: [Security Improvement] Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The `write-backup-file` IPC handler joined a user-provided `folder` with a `filename` without validation.
 **Learning:** `path.join()` in Node.js discards previous segments if a segment is an absolute path (e.g., `path.join('/safe/dir', '/etc/passwd')` returns `/etc/passwd`). This allowed arbitrary file overwrites even if the `folder` argument was fixed/safe (though in this case it wasn't).
 **Prevention:** Always validate `filename` arguments in IPC handlers to ensure they are relative and contain no path separators (`/` or `\`) or `..` segments. Use `path.basename()` and explicit checks.
+
+## 2025-05-18 - Content Security Policy in Vite/Electron
+**Vulnerability:** Missing CSP headers in Electron allowed potential XSS.
+**Learning:** Adding CSP to `index.html` breaks Vite's dev server due to inline scripts used for HMR. Using `vite-plugin-html` or a custom inline plugin with `apply: 'build'` is critical to secure production without breaking development.
+**Prevention:** Use a build-time transform to inject strict CSP meta tags only for production builds.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,21 @@ export default defineConfig(() => ({
     port: 62153,
   },
   base: './',
-  plugins: [dyadComponentTagger(), react()],
+  plugins: [
+    dyadComponentTagger(),
+    react(),
+    {
+      name: 'html-csp',
+      apply: 'build',
+      transformIndexHtml(html) {
+        return html.replace(
+          '<head>',
+          `<head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.frankfurter.dev; font-src 'self' data:;">`
+        );
+      },
+    },
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
🛡️ Sentinel: [Security Improvement] Add Content Security Policy

💡 Vulnerability: Missing Content Security Policy (CSP) allowed potential XSS attacks.
🎯 Impact: Attackers could execute arbitrary scripts or exfiltrate data.
🔧 Fix: Added a strict CSP via Vite build plugin (production only).
✅ Verification: Verified build output contains correct meta tag.

---
*PR created automatically by Jules for task [16499337669112683580](https://jules.google.com/task/16499337669112683580) started by @nrajesh*