### PR TITLE
🎨 Palette: Add loading state to transaction save button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2026-02-16 - Sortable Table Headers
 **Learning:** Making `<th>` elements interactive via `onClick` breaks keyboard accessibility (tab focus) and semantic structure. Screen readers expect `aria-sort` on the `<th>` but interaction on a child button.
 **Action:** Wrap header content in a semantic `<button type="button">` that fills the cell. Move event handlers to the button, but keep `aria-sort` on the parent `<th>`. Use flex utilities to handle alignment (e.g., `justify-end` for right-aligned columns).
+
+## 2026-02-17 - Combobox Interaction Pattern
+**Learning:** The `Combobox` component (specifically in `AddEditTransactionDialog`) renders as a direct text input (via `cmdk`) rather than a button-triggered popover. Automation scripts targeting these fields should look for `input` elements by placeholder text (e.g., "Search accounts...") instead of `button[role='combobox']`.
+**Action:** When automating or testing forms using `Combobox`, target the input field directly for typing and filtering, and use `role="option"` or `[cmdk-item]` to select results.

--- a/src/components/dialogs/AddEditTransactionDialog.tsx
+++ b/src/components/dialogs/AddEditTransactionDialog.tsx
@@ -491,7 +491,10 @@ const AddEditTransactionDialog: React.FC<AddEditTransactionDialogProps> = ({
                 )}
 
                 <DialogFooter className="col-span-2">
-                  <Button type="submit">
+                  <Button type="submit" disabled={form.formState.isSubmitting}>
+                    {form.formState.isSubmitting && (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    )}
                     {isEditMode ? "Save Changes" : "Add Transaction"}
                   </Button>
                 </DialogFooter>


### PR DESCRIPTION
Added a loading state to the "Add/Edit Transaction" dialog's save button. This disables the button and shows a spinner while the transaction is being saved, preventing multiple submissions and providing better visual feedback to the user. Verified with Playwright script and existing tests.

---
*PR created automatically by Jules for task [10696566660699153802](https://jules.google.com/task/10696566660699153802) started by @nrajesh*