### PR TITLE
Unified menu system

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -389,12 +389,6 @@ const MobileHeaderActionsMenu = ({
             </Link>
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem asChild className={actionItemClassName}>
-          <Link to="/language">
-            <LanguageIcon className="h-5 w-5" />
-            {t("layout.nav.languages", { defaultValue: "Languages" })}
-          </Link>
-        </DropdownMenuItem>
         {hasTourForCurrentRoute && (
           <DropdownMenuItem onClick={startTour} className={actionItemClassName}>
             <HelpCircle className="h-5 w-5" />
@@ -876,7 +870,7 @@ const Layout = () => {
                 </Link>
               </Button>
             )}
-            <LanguageSwitcher />
+            <LanguageSwitcher showLanguageSettings />
             {hasTourForCurrentRoute && (
               <Button
                 variant="ghost"
@@ -910,8 +904,25 @@ const Layout = () => {
               </span>
             </Button>
             <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
+            {!isHomepageMobilePreview && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
+                onClick={logout}
+                aria-label={t("layout.nav.logout", {
+                  defaultValue: "Log out",
+                })}
+              >
+                <LogOut className="h-5 w-5 text-slate-600 dark:text-gray-300" />
+                <span className="sr-only">
+                  {t("layout.nav.logout", { defaultValue: "Log out" })}
+                </span>
+              </Button>
+            )}
           </div>
           <div className="flex items-center gap-2 md:hidden">
+            <LanguageSwitcher showLanguageSettings />
             <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
             <MobileHeaderActionsMenu
               displayName={displayName}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -37,16 +37,19 @@ const SiteFooter = ({ extraLinks = [] }: SiteFooterProps) => {
           </span>
         </div>
 
-        <div className="flex max-w-full flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
+        <div className="flex max-w-full flex-col items-center gap-1 text-xs text-muted-foreground sm:flex-row sm:flex-wrap sm:justify-center sm:gap-x-4 sm:gap-y-2">
           <Link to="/privacy" className={footerLinkClassName}>
             {t("layout.footer.privacyPolicy", {
               defaultValue: "Privacy Policy",
             })}
           </Link>
-          <span className="text-muted-foreground/30" aria-hidden="true">
+          <span
+            className="hidden text-muted-foreground/30 sm:inline"
+            aria-hidden="true"
+          >
             |
           </span>
-          <span>
+          <span className="hidden sm:inline">
             {t("layout.footer.madeBy", { defaultValue: "Made by " })}
             <a
               href="https://imaginest.nl"
@@ -58,6 +61,34 @@ const SiteFooter = ({ extraLinks = [] }: SiteFooterProps) => {
             </a>
             {t("layout.footer.withHeart", {
               defaultValue: " with ❤️ for your financial ",
+            })}
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={footerLinkClassName}
+              aria-label={t("layout.footer.githubAria", {
+                defaultValue: "Open Vaulted Money on GitHub",
+              })}
+            >
+              {t("layout.footer.freedom", { defaultValue: "freedom" })}
+            </a>
+          </span>
+          <span className="sm:hidden">
+            {t("layout.footer.madeBy", { defaultValue: "Made by " })}
+            <a
+              href="https://imaginest.nl"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={footerLinkClassName}
+            >
+              Imaginest
+            </a>
+            {" with ❤️"}
+          </span>
+          <span className="sm:hidden">
+            {t("layout.footer.forYourFinancial", {
+              defaultValue: "For your financial ",
             })}
             <a
               href={GITHUB_REPO_URL}

--- a/src/components/language/LanguageSwitcher.tsx
+++ b/src/components/language/LanguageSwitcher.tsx
@@ -47,7 +47,13 @@ const getBuiltInLanguageLabel = (
   return `${language.nativeName} (${translatedName})`;
 };
 
-export const LanguageSwitcher = () => {
+interface LanguageSwitcherProps {
+  showLanguageSettings?: boolean;
+}
+
+export const LanguageSwitcher = ({
+  showLanguageSettings = false,
+}: LanguageSwitcherProps) => {
   const { t, i18n: i18nInstance } = useTranslation();
   const [, bumpLanguageListVersion] = React.useReducer(
     (value: number) => value + 1,
@@ -181,14 +187,18 @@ export const LanguageSwitcher = () => {
             );
           })}
         </div>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild className="cursor-pointer">
-          <Link to="/language">
-            {t("language.openLanguageSettings", {
-              defaultValue: "Language settings",
-            })}
-          </Link>
-        </DropdownMenuItem>
+        {showLanguageSettings && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link to="/language">
+                {t("language.openLanguageSettings", {
+                  defaultValue: "Language settings",
+                })}
+              </Link>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -354,7 +354,7 @@ const HomePage = () => {
   return (
     <main className="min-h-screen overflow-x-hidden bg-background pt-16 text-foreground sm:pt-24">
       <header className="fixed inset-x-0 top-0 z-50 border-b border-slate-200/70 bg-white/90 px-3 shadow-sm backdrop-blur dark:border-slate-800/80 dark:bg-slate-950/90 sm:px-4">
-        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-3 sm:h-24">
+        <div className="mx-auto flex min-h-16 max-w-7xl items-center justify-between gap-3">
           <Link
             to="/"
             className="flex shrink-0 items-center"
@@ -391,9 +391,7 @@ const HomePage = () => {
           </nav>
 
           <div className="flex shrink-0 items-center gap-2">
-            <div className="hidden sm:block">
-              <LanguageSwitcher />
-            </div>
+            <LanguageSwitcher />
             <Button
               variant="ghost"
               size="icon"
@@ -470,9 +468,6 @@ const HomePage = () => {
                   ))}
                 </nav>
                 <div className="mt-auto border-t border-slate-200/60 px-3 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-4 dark:border-slate-800/60">
-                  <div className="mb-3 px-1">
-                    <LanguageSwitcher />
-                  </div>
                   <Button
                     asChild
                     className="h-11 w-full rounded-lg bg-[hsl(var(--brand-accent))] text-[0.95rem] font-semibold text-white hover:bg-[hsl(var(--brand-accent-strong))]"

--- a/src/pages/LedgerEntryPage.tsx
+++ b/src/pages/LedgerEntryPage.tsx
@@ -41,14 +41,6 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Search, Trash2 } from "lucide-react";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -58,6 +50,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import ConfirmationDialog from "@/components/dialogs/ConfirmationDialog";
 import { LanguageSwitcher } from "@/components/language/LanguageSwitcher";
 import { useTranslation } from "react-i18next";
@@ -490,8 +489,9 @@ const LedgerEntryPage = () => {
         isHomepageMobilePreview && "h-screen overflow-hidden",
       )}
     >
-      <header className="sticky top-0 z-40 border-b border-border/60 bg-gray-50/90 px-4 pt-[env(safe-area-inset-top)] backdrop-blur dark:bg-gray-900/90">
-        <div className="mx-auto flex min-h-16 w-full max-w-3xl items-center justify-between gap-3">
+      <header className="sticky top-0 z-40 flex min-h-16 items-center justify-end border-b border-border/60 bg-gray-50/90 px-4 pt-[env(safe-area-inset-top)] backdrop-blur dark:bg-gray-900/90 sm:px-6">
+        {/* ── Desktop icon row ── */}
+        <div className="hidden items-center gap-2 sm:flex">
           {isHomepageMobilePreview ? (
             <Button
               type="button"
@@ -523,81 +523,103 @@ const LedgerEntryPage = () => {
               </Link>
             </Button>
           )}
-
-          <div className="tour-theme-toggle hidden items-center gap-2 sm:flex">
-            <LanguageSwitcher />
-            {hasTourForCurrentRoute && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-                onClick={startTour}
-                aria-label={t("helpTour.start")}
-              >
-                <HelpCircle className="h-5 w-5 text-slate-600 dark:text-gray-300" />
-                <span className="sr-only">{t("helpTour.start")}</span>
-              </Button>
-            )}
+          <LanguageSwitcher />
+          {hasTourForCurrentRoute && (
             <Button
               variant="ghost"
               size="icon"
               className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-              onClick={() =>
-                setTheme(resolvedTheme === "dark" ? "light" : "dark")
-              }
-              aria-label={t("layout.toggleTheme", {
-                defaultValue: "Toggle theme",
-              })}
+              onClick={startTour}
+              aria-label={t("helpTour.start")}
             >
-              {resolvedTheme === "dark" ? (
-                <Sun className="h-5 w-5 text-amber-400" />
-              ) : (
-                <Moon className="h-5 w-5 text-slate-600" />
-              )}
+              <HelpCircle className="h-5 w-5 text-slate-600 dark:text-gray-300" />
+              <span className="sr-only">{t("helpTour.start")}</span>
             </Button>
-            <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
-          </div>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
+            onClick={() =>
+              setTheme(resolvedTheme === "dark" ? "light" : "dark")
+            }
+            aria-label={t("layout.toggleTheme", {
+              defaultValue: "Toggle theme",
+            })}
+          >
+            {resolvedTheme === "dark" ? (
+              <Sun className="h-5 w-5 text-amber-400" />
+            ) : (
+              <Moon className="h-5 w-5 text-slate-600" />
+            )}
+          </Button>
+          <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
+        </div>
 
-          <div className="flex items-center gap-2 sm:hidden">
-            <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
-                  aria-label="More actions"
-                >
-                  <MoreHorizontal className="h-5 w-5 text-slate-600 dark:text-gray-300" />
-                  <span className="sr-only">More actions</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                className="w-[min(100vw-2rem,16rem)]"
+        {/* ── Mobile overflow menu (matches Layout's MobileHeaderActionsMenu) ── */}
+        <div className="flex items-center gap-2 sm:hidden">
+          <LanguageSwitcher />
+          <FeedbackLauncher triggerClassName="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700" />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-full bg-white/80 dark:bg-gray-800/80 backdrop-blur shadow-sm hover:bg-white dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700"
+                aria-label="More actions"
               >
-                <DropdownMenuLabel>Ledger actions</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem asChild>
-                  <Link to="/language">
-                    {t("layout.nav.languages", { defaultValue: "Languages" })}
+                <MoreHorizontal className="h-5 w-5 text-slate-600 dark:text-gray-300" />
+                <span className="sr-only">More actions</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              sideOffset={10}
+              className="w-[min(100vw-1.5rem,20rem)] rounded-2xl p-2 shadow-xl"
+            >
+              <div className="rounded-xl px-3 py-3">
+                <p className="text-sm text-muted-foreground">
+                  {t("ledgerEntry.quickActions", {
+                    defaultValue: "Quick actions",
+                  })}
+                </p>
+              </div>
+              <DropdownMenuSeparator className="mx-1" />
+              {!isHomepageMobilePreview && (
+                <DropdownMenuItem
+                  asChild
+                  className="min-h-14 rounded-xl px-4 py-3 text-[1.05rem] font-medium text-foreground gap-3"
+                >
+                  <Link to="/">
+                    <Home className="h-5 w-5" />
+                    {t("home.actions.home", { defaultValue: "Home" })}
                   </Link>
                 </DropdownMenuItem>
-                {hasTourForCurrentRoute && (
-                  <DropdownMenuItem onClick={startTour}>
-                    {t("helpTour.start", { defaultValue: "Start tour" })}
-                  </DropdownMenuItem>
-                )}
+              )}
+              {hasTourForCurrentRoute && (
                 <DropdownMenuItem
-                  onClick={() =>
-                    setTheme(resolvedTheme === "dark" ? "light" : "dark")
-                  }
+                  onClick={startTour}
+                  className="min-h-14 rounded-xl px-4 py-3 text-[1.05rem] font-medium text-foreground gap-3"
                 >
-                  {resolvedTheme === "dark" ? "Light mode" : "Dark mode"}
+                  <HelpCircle className="h-5 w-5" />
+                  {t("helpTour.start", { defaultValue: "Start help tour" })}
                 </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+              )}
+              <DropdownMenuItem
+                onClick={() =>
+                  setTheme(resolvedTheme === "dark" ? "light" : "dark")
+                }
+                className="min-h-14 rounded-xl px-4 py-3 text-[1.05rem] font-medium text-foreground gap-3"
+              >
+                {resolvedTheme === "dark" ? (
+                  <Sun className="h-5 w-5" />
+                ) : (
+                  <Moon className="h-5 w-5" />
+                )}
+                {resolvedTheme === "dark" ? "Light mode" : "Dark mode"}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </header>
       <div


### PR DESCRIPTION
fix(ui): unify header menus and hide Language Settings when no ledger active

- LanguageSwitcher: add showLanguageSettings prop to conditionally show the settings link only inside a ledger
- LedgerEntryPage: replace text-only mobile dropdown with icon buttons and overflow menu matching Layout; make header full-width so icons right-align consistently with in-app pages
- Layout: add LanguageSwitcher dropdown to mobile header, remove redundant Languages link from overflow menu, add logout icon to desktop header row
- HomePage: move language switcher to always-visible header position, shrink header height to match ledger select
- SiteFooter: split mobile footer into three centered lines